### PR TITLE
Add pre-order button state

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -64,6 +64,7 @@ describe('Browser Extension Test', () => {
 
       const element = shadowRoot.querySelector('a[data-inventory-state-normalized]') as HTMLLinkElement
       return {
+        inventoryState: element?.dataset.inventoryState,
         inventoryStateNormalized: element?.dataset.inventoryStateNormalized,
         textContent: element?.textContent,
         target: element?.target,
@@ -74,6 +75,7 @@ describe('Browser Extension Test', () => {
 
     const href = new URL(result?.href ?? '')
 
+    expect(result?.inventoryState).toBe('InStock')
     expect(result?.inventoryStateNormalized).toBe('available')
     expect(result?.textContent).toBe('In Stock')
     expect(result?.target).toBe('_blank')
@@ -97,6 +99,7 @@ describe('Browser Extension Test', () => {
 
       const element = shadowRoot.querySelector('a[data-inventory-state-normalized]') as HTMLLinkElement
       return {
+        inventoryState: element?.dataset.inventoryState,
         inventoryStateNormalized: element?.dataset.inventoryStateNormalized,
         textContent: element?.textContent,
         target: element?.target,
@@ -107,6 +110,7 @@ describe('Browser Extension Test', () => {
 
     const href = new URL(result?.href ?? '')
 
+    expect(result?.inventoryState).toBe('OutOfStock')
     expect(result?.inventoryStateNormalized).toBe('unavailable')
     expect(result?.textContent).toBe('Notify Me When Available')
     expect(result?.target).toBe('_blank')
@@ -115,6 +119,41 @@ describe('Browser Extension Test', () => {
     expect(href.hostname).toBe('isinstock.com')
     expect(href.pathname).toBe('/track')
     expect(href.searchParams.get('url')).toBe('https://isinstock.com/store/products/unavailable')
+    expect(href.searchParams.get('utm_campaign')).toBe('web_extension')
+  })
+
+  test('pre-order product renders pre-order button', async () => {
+    await page.goto('https://isinstock.com/store/products/pre-order', {waitUntil: 'networkidle0'})
+    await page.waitForSelector('#isinstock-button')
+    const result = await page.evaluate(() => {
+      const button = document.querySelector('#isinstock-button')
+      if (!button) return null
+
+      const shadowRoot = button.shadowRoot
+      if (!shadowRoot) return null
+
+      const element = shadowRoot.querySelector('a[data-inventory-state-normalized]') as HTMLLinkElement
+      return {
+        inventoryState: element?.dataset.inventoryState,
+        inventoryStateNormalized: element?.dataset.inventoryStateNormalized,
+        textContent: element?.textContent,
+        target: element?.target,
+        rel: element?.rel,
+        href: element?.href,
+      }
+    })
+
+    const href = new URL(result?.href ?? '')
+
+    expect(result?.inventoryState).toBe('PreOrder')
+    expect(result?.inventoryStateNormalized).toBe('available')
+    expect(result?.textContent).toBe('Pre-Order')
+    expect(result?.target).toBe('_blank')
+    expect(result?.rel).toBe('noreferrer')
+    expect(href.protocol).toBe('https:')
+    expect(href.hostname).toBe('isinstock.com')
+    expect(href.pathname).toBe('/track')
+    expect(href.searchParams.get('url')).toBe('https://isinstock.com/store/products/pre-order')
     expect(href.searchParams.get('utm_campaign')).toBe('web_extension')
   })
 

--- a/src/elements/isinstock-button.tsx
+++ b/src/elements/isinstock-button.tsx
@@ -35,10 +35,11 @@ const IsInStockButton = ({productValidation}: IsInStockButtonProps) => {
       target="_blank"
       class="btn"
       rel="noreferrer"
+      data-inventory-state={productValidation.availability}
       data-inventory-state-normalized={InventoryStateNormalized.Available}
     >
       <img class="isinstock-logo" width="16" height="16" src={availableImg} />
-      <span>In Stock</span>
+      <span>{productValidation.availability === 'PreOrder' ? 'Pre-Order' : 'In Stock'}</span>
     </a>
   )
 }
@@ -63,6 +64,7 @@ const OutOfStockButton = ({productValidation}: IsInStockButtonProps) => {
       target="_blank"
       class="btn"
       rel="noreferrer"
+      data-inventory-state={productValidation.availability}
       data-inventory-state-normalized={InventoryStateNormalized.Unavailable}
     >
       <img class="isinstock-logo" width="16" height="16" src={unavailableImg} />

--- a/src/elements/isinstock-button/style.css
+++ b/src/elements/isinstock-button/style.css
@@ -9,7 +9,7 @@
 }
 
 .btn {
-  @apply inline-flex w-full justify-center cursor-pointer items-center gap-x-3 whitespace-nowrap rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 transition duration-150 hover:bg-gray-50;
+  @apply inline-flex w-full justify-center cursor-pointer items-center gap-x-3 whitespace-nowrap rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 transition duration-150 hover:bg-gray-50 select-none;
 }
 
 .isinstock-button {


### PR DESCRIPTION
Right now renders "In Stock":

![CleanShot 2023-11-27 at 23 29 01@2x](https://github.com/isinstock/browser-extension/assets/79995/4e6bbed9-bc1f-4c9f-a9ec-4b095ee3c9bf)

Will render "Pre-Order":

![CleanShot 2023-11-27 at 23 28 44@2x](https://github.com/isinstock/browser-extension/assets/79995/9848536d-ab7c-4af7-8fc8-240c5397c6c8)
